### PR TITLE
Replace default export with named export

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "versioned-value-map",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "The immutable container of time-series data ",
   "main": "./dist/index.js",
   "jsnext:main": "./jsnext.js",

--- a/src/VersionedValue.js
+++ b/src/VersionedValue.js
@@ -14,7 +14,7 @@ export type PlainVersionedValue<T> = {
 
 export type MixedVersionedValue<T> = PlainVersionedValue<T> | VersionedValue<T>
 
-export default class VersionedValue<T> {
+export class VersionedValue<T> {
   name: string
   records: Array<Record<T>>
 

--- a/src/VersionedValueMap.js
+++ b/src/VersionedValueMap.js
@@ -1,5 +1,5 @@
 // @flow
-import VersionedValue from './VersionedValue.js'
+import { VersionedValue } from './VersionedValue.js'
 import type { MixedVersionedValue } from './VersionedValue.js'
 import { retargetToProp, assign } from 'power-assign/jsnext'
 type ISOString = string
@@ -25,7 +25,7 @@ function createItems(plainItems: { [key: string]: MixedVersionedValue<*> }): { [
   return items
 }
 
-export default class VersionedValueMap {
+export class VersionedValueMap {
 
   items: { [name: string]: VersionedValue<*> }
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,3 @@
 // @flow
-export { default as VersionedValue }from './VersionedValue.js'
-export { default as VersionedValueMap } from './VersionedValueMap.js'
+export * from './VersionedValue.js'
+export * from './VersionedValueMap.js'


### PR DESCRIPTION
## problem
```
import { VersionedValueMap, type PlainVersionedValueMap } from 'versioned-value-map/jsnext'
                                 ^ This module has no named export called `PlainVersionedValueMap` 
```

## solusion
Replace default export with named export and change src/index.js

```js
// @flow
export * from './VersionedValue.js'
export * from './VersionedValueMap.js'
```
